### PR TITLE
Updated Zookeeper to latest version, 3.5.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,31 @@
 language: go
 
 go:
+  # n.b. For golang release history, see https://golang.org/doc/devel/release.html
   - tip
-  - "1.10"
-  - 1.9
-  - 1.8
-  - 1.7
+  - "1.13.8"
+  - "1.12.17"
+  - "1.11.13"
+  - "1.10.8"
+  - "1.9.7"
 
-before_install:
-  - curl --silent --show-error -O https://archive.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
-  - tar -xzf zookeeper-3.4.6.tar.gz
+env:
+  global:
+    - ZOOKEEPER_VERSION: 3.5.7
+
+before_script:
+  #- "curl --silent --show-error -O https://archive.apache.org/dist/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz"
+  - env
+  - "set -x"
+  - "ls -lah"
+  - pwd
+  - curl --silent --show-error -O https://archive.apache.org/dist/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz"
+  - "ls -lah"
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
 
 script:
+  - tar -xzf zookeeper-$ZOOKEEPER_VERSION.tar.gz
   - go test ./...
 
 notifications:

--- a/candidate/candidate.go
+++ b/candidate/candidate.go
@@ -11,9 +11,8 @@ import (
 
 	"github.com/gigawattio/concurrency"
 	zkutil "github.com/gigawattio/zklib/util"
-
-	log "github.com/Sirupsen/logrus"
 	"github.com/samuel/go-zookeeper/zk"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/candidate/candidate_test.go
+++ b/candidate/candidate_test.go
@@ -11,12 +11,11 @@ import (
 	"github.com/gigawattio/zklib/candidate"
 	zktestutil "github.com/gigawattio/zklib/testutil"
 	zkutil "github.com/gigawattio/zklib/util"
-
-	log "github.com/Sirupsen/logrus"
 	"github.com/kr/pretty"
 	"github.com/montanaflynn/stats"
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/candidate/participant.go
+++ b/candidate/participant.go
@@ -7,9 +7,8 @@ import (
 	"time"
 
 	"github.com/gigawattio/errorlib"
-
-	log "github.com/Sirupsen/logrus"
 	"github.com/samuel/go-zookeeper/zk"
+	log "github.com/sirupsen/logrus"
 )
 
 type ParticipantConfig struct {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -9,15 +9,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/gigawattio/concurrency"
 	"github.com/gigawattio/gentle"
 	"github.com/gigawattio/zklib/cluster/primitives"
 	"github.com/gigawattio/zklib/util"
-
-	log "github.com/Sirupsen/logrus"
-	"github.com/cenkalti/backoff"
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gigawattio/netlib"
 	"github.com/gigawattio/testlib"
 	"github.com/gigawattio/zklib/cluster"
 	"github.com/gigawattio/zklib/cluster/primitives"
 	"github.com/gigawattio/zklib/testutil"
+	log "github.com/sirupsen/logrus"
 )
 
 var zkTimeout = 1 * time.Second

--- a/cluster/util.go
+++ b/cluster/util.go
@@ -3,8 +3,8 @@ package cluster
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
+	log "github.com/sirupsen/logrus"
 )
 
 // retryUntilSuccess will keep attempting an operation until it succeeds.

--- a/dmutex/distributed_mutex_service.go
+++ b/dmutex/distributed_mutex_service.go
@@ -7,13 +7,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/gigawattio/zklib/cluster"
 	"github.com/gigawattio/zklib/cluster/primitives"
 	zkutil "github.com/gigawattio/zklib/util"
-
-	log "github.com/Sirupsen/logrus"
-	"github.com/cenkalti/backoff"
 	"github.com/samuel/go-zookeeper/zk"
+	log "github.com/sirupsen/logrus"
 )
 
 type DistributedMutexService struct {

--- a/testutil/with_zk.go
+++ b/testutil/with_zk.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/util/recursively_delete.go
+++ b/util/recursively_delete.go
@@ -4,9 +4,8 @@ import (
 	"time"
 
 	"github.com/gigawattio/concurrency"
-
-	log "github.com/Sirupsen/logrus"
 	"github.com/samuel/go-zookeeper/zk"
+	log "github.com/sirupsen/logrus"
 )
 
 func RecursivelyDelete(conn *zk.Conn, path string, numRetries ...int) error {

--- a/util/with_zk_session.go
+++ b/util/with_zk_session.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/samuel/go-zookeeper/zk"
+	log "github.com/sirupsen/logrus"
 )
 
 // WithZkSession invokes the invoker-supplied callback function once the


### PR DESCRIPTION
Also updated Travis CI Golang testing versions for 2020.

- Added Go versions 1.9.7, 1.10.8, 1.11.13, 1.12.17, and 1.13.8.
- Dropped Go versions 1.8, 1.9, and 1.10.